### PR TITLE
use newer resource URI for sending SMS

### DIFF
--- a/sms.go
+++ b/sms.go
@@ -48,7 +48,7 @@ func (sms *SmsResponse) DateSentAsTime() (time.Time, error) {
 func (twilio *Twilio) SendSMS(from, to, body, statusCallback, applicationSid string) (*SmsResponse, *Exception, error) {
 	var smsResponse *SmsResponse
 	var exception *Exception
-	twilioUrl := twilio.BaseUrl + "/Accounts/" + twilio.AccountSid + "/SMS/Messages.json"
+	twilioUrl := twilio.BaseUrl + "/Accounts/" + twilio.AccountSid + "/Messages.json"
 
 	formValues := url.Values{}
 	formValues.Set("From", from)


### PR DESCRIPTION
As per https://www.twilio.com/help/faq/sms/does-twilio-support-concatenated-sms-messages-or-messages-over-160-characters

```
Note: the <SMS> resource URI is deprecated and does not support >160 characters
```
