### PR TITLE
Don't pass empty voice callback parameters.

### DIFF
--- a/voice.go
+++ b/voice.go
@@ -87,14 +87,32 @@ func (twilio *Twilio) CallWithUrlCallbacks(from, to string, callbackParameters *
 	formValues.Set("From", from)
 	formValues.Set("To", to)
 	formValues.Set("Url", callbackParameters.Url)
-	formValues.Set("Method", callbackParameters.Method)
-	formValues.Set("FallbackUrl", callbackParameters.FallbackUrl)
-	formValues.Set("FallbackMethod", callbackParameters.FallbackMethod)
-	formValues.Set("StatusCallback", callbackParameters.StatusCallback)
-	formValues.Set("StatusCallbackMethod", callbackParameters.StatusCallbackMethod)
-	formValues.Set("SendDigits", callbackParameters.SendDigits)
-	formValues.Set("IfMachine", callbackParameters.IfMachine)
-	formValues.Set("Timeout", strconv.Itoa(callbackParameters.Timeout))
+
+	// Optional values
+	if callbackParameters.Method != "" {
+		formValues.Set("Method", callbackParameters.Method)
+	}
+	if callbackParameters.FallbackUrl != "" {
+		formValues.Set("FallbackUrl", callbackParameters.FallbackUrl)
+	}
+	if callbackParameters.FallbackMethod != "" {
+		formValues.Set("FallbackMethod", callbackParameters.FallbackMethod)
+	}
+	if callbackParameters.StatusCallback != "" {
+		formValues.Set("StatusCallback", callbackParameters.StatusCallback)
+	}
+	if callbackParameters.StatusCallbackMethod != "" {
+		formValues.Set("StatusCallbackMethod", callbackParameters.StatusCallbackMethod)
+	}
+	if callbackParameters.SendDigits != "" {
+		formValues.Set("SendDigits", callbackParameters.SendDigits)
+	}
+	if callbackParameters.IfMachine != "" {
+		formValues.Set("IfMachine", callbackParameters.IfMachine)
+	}
+	if callbackParameters.Timeout != 0 {
+		formValues.Set("Timeout", strconv.Itoa(callbackParameters.Timeout))
+	}
 	if callbackParameters.Record {
 		formValues.Set("Record", "true")
 	} else {


### PR DESCRIPTION
Currently when optional `CallbackParameters` are blank, they are passed to the Twilio API as an empty string.  Twilio interprets these as invalid parameters (e.g. the empty string is an invalid HTTP method).  This change only sets non-empty parameters on the form.

We use a similar technique for optional parameters [in the stripe-go bindings](https://github.com/stripe/stripe-go/blob/master/token/client.go#L32).  In that case we use a `len` check instead of an `== ""` -- I'm reasonably indifferent between those approaches.
