### PR TITLE
Add support for verifying Twilio request signatures.

### DIFF
--- a/util.go
+++ b/util.go
@@ -1,0 +1,84 @@
+package gotwilio
+
+import (
+	"bytes"
+	"crypto/hmac"
+	"crypto/sha1"
+	"encoding/base64"
+	"errors"
+	"net/http"
+	"net/url"
+	"sort"
+)
+
+// GenerateSignature computes the Twilio signature for verifying the
+// authenticity of a request.  It is based on the specification at:
+// https://www.twilio.com/docs/security#validating-requests
+func (twilio *Twilio) GenerateSignature(url string, form url.Values) ([]byte, error) {
+	var buf bytes.Buffer
+
+	buf.WriteString(url)
+
+	keys := make(sort.StringSlice, 0, len(form))
+	for k := range form {
+		keys = append(keys, k)
+	}
+
+	keys.Sort()
+
+	for _, k := range keys {
+		buf.WriteString(k)
+		for _, v := range form[k] {
+			buf.WriteString(v)
+		}
+	}
+
+	mac := hmac.New(sha1.New, []byte(twilio.AuthToken))
+	mac.Write(buf.Bytes())
+
+	var expected bytes.Buffer
+	coder := base64.NewEncoder(base64.StdEncoding, &expected)
+	_, err := coder.Write(mac.Sum(nil))
+	if err != nil {
+		return nil, err
+	}
+
+	err = coder.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	return expected.Bytes(), nil
+}
+
+// CheckRequestSignature checks that the X-Twilio-Signature header on a request
+// matches the expected signature defined by the GenerateSignature function.
+//
+// The baseUrl parameter will be prepended to the request URL. It is useful for
+// specifying the protocol and host parts of the server URL hosting your endpoint.
+//
+// Passing a non-POST request or a request without the X-Twilio-Signature
+// header is an error.
+func (twilio *Twilio) CheckRequestSignature(r *http.Request, baseURL string) (bool, error) {
+	if r.Method != "POST" {
+		return false, errors.New("Checking signatures on non-POST requests is not implemented")
+	}
+
+	if err := r.ParseForm(); err != nil {
+		return false, err
+	}
+
+	url := baseURL + r.URL.String()
+
+	expected, err := twilio.GenerateSignature(url, r.PostForm)
+	if err != nil {
+		return false, err
+	}
+
+	actual := r.Header.Get("X-Twilio-Signature")
+	if actual == "" {
+		return false, errors.New("Request does not have a twilio signature header")
+	}
+
+	return hmac.Equal(expected, []byte(actual)), nil
+}

--- a/util_test.go
+++ b/util_test.go
@@ -1,0 +1,70 @@
+package gotwilio
+
+import (
+	"bytes"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"testing"
+)
+
+const (
+	// Magic strings from https://github.com/twilio/twilio-python
+	testServerURL      = "http://www.postbin.org"
+	testAuthToken      = "1c892n40nd03kdnc0112slzkl3091j20"
+	testValidSignature = "fF+xx6dTinOaCdZ0aIeNkHr/ZAA="
+)
+
+func TestCheckSignature(t *testing.T) {
+	twilio := Twilio{
+		AuthToken: testAuthToken,
+	}
+
+	// Magic strings from https://github.com/twilio/twilio-python
+	u, err := url.Parse("/1ed898x")
+	if err != nil {
+		t.Fatal(err)
+	}
+	h := http.Header{
+		"Content-Type":       []string{"application/x-www-form-urlencoded"},
+		"X-Twilio-Signature": []string{testValidSignature},
+	}
+	b := bytes.NewBufferString(`FromZip=89449&From=%2B15306666666&` +
+		`FromCity=SOUTH+LAKE+TAHOE&ApiVersion=2010-04-01&To=%2B15306384866&` +
+		`CallStatus=ringing&CalledState=CA&FromState=CA&Direction=inbound&` +
+		`ToCity=OAKLAND&ToZip=94612&CallerCity=SOUTH+LAKE+TAHOE&FromCountry=US&` +
+		`CallerName=CA+Wireless+Call&CalledCity=OAKLAND&CalledCountry=US&` +
+		`Caller=%2B15306666666&CallerZip=89449&AccountSid=AC9a9f9392lad99kla0sklakjs90j092j3&` +
+		`Called=%2B15306384866&CallerCountry=US&CalledZip=94612&CallSid=CAd800bb12c0426a7ea4230e492fef2a4f&` +
+		`CallerState=CA&ToCountry=US&ToState=CA`)
+
+	r := http.Request{
+		Method: "POST",
+		URL:    u,
+		Header: h,
+		Body:   ioutil.NopCloser(b),
+	}
+
+	valid, err := twilio.CheckRequestSignature(&r, testServerURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !valid {
+		t.Fatal("Expected signature to be valid")
+	}
+
+	h["X-Twilio-Signature"] = []string{"foo"}
+	valid, err = twilio.CheckRequestSignature(&r, testServerURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if valid {
+		t.Fatal("Expected signature to be invalid")
+	}
+
+	delete(h, "X-Twilio-Signature")
+	valid, err = twilio.CheckRequestSignature(&r, testServerURL)
+	if err == nil {
+		t.Fatal("Expected an error verifying a request without a signature header")
+	}
+}


### PR DESCRIPTION
This adds support to the client for verifying the Twilio signature on HTTP requests.  It is based on the documentation [0] and the implementation in the official Python bindings [1].  I notice that this duplicates work done in the as-yet-unmerged #3.

If the shape of this looks good, I can add documentation for it.

[0] https://www.twilio.com/docs/security#validating-requests
[1] https://github.com/twilio/twilio-python
