### PR TITLE
Allows user-configured http.Client to be passed into NewTwilioClient.

### DIFF
--- a/gotwilio.go
+++ b/gotwilio.go
@@ -25,7 +25,12 @@ type Exception struct {
 }
 
 // Create a new Twilio struct.
-func NewTwilioClient(accountSid, authToken string, HTTPClient *http.Client) *Twilio {
+func NewTwilioClient(accountSid, authToken string) *Twilio {
+	return NewTwilioClientCustomHTTP(accountSid, authToken, nil)
+}
+
+// Create a new Twilio client, optionally using a custom http.Client
+func NewTwilioClientCustomHTTP(accountSid, authToken string, HTTPClient *http.Client) *Twilio {
 	twilioUrl := "https://api.twilio.com/2010-04-01" // Should this be moved into a constant?
 
 	if HTTPClient == nil {

--- a/gotwilio.go
+++ b/gotwilio.go
@@ -25,9 +25,14 @@ type Exception struct {
 }
 
 // Create a new Twilio struct.
-func NewTwilioClient(accountSid, authToken string) *Twilio {
+func NewTwilioClient(accountSid, authToken string, HTTPClient *http.Client) *Twilio {
 	twilioUrl := "https://api.twilio.com/2010-04-01" // Should this be moved into a constant?
-	return &Twilio{accountSid, authToken, twilioUrl, http.DefaultClient}
+
+	if HTTPClient == nil {
+		HTTPClient = http.DefaultClient
+	}
+
+	return &Twilio{accountSid, authToken, twilioUrl, HTTPClient}
 }
 
 func (twilio *Twilio) post(formValues url.Values, twilioUrl string) (*http.Response, error) {

--- a/gotwilio_test.go
+++ b/gotwilio_test.go
@@ -1,6 +1,7 @@
 package gotwilio
 
 import (
+	"net/http"
 	"testing"
 )
 
@@ -16,7 +17,7 @@ func init() {
 
 func TestSMS(t *testing.T) {
 	msg := "Welcome to gotwilio"
-	twilio := NewTwilioClient(params["SID"], params["TOKEN"])
+	twilio := NewTwilioClient(params["SID"], params["TOKEN"], http.DefaultClient)
 	_, exc, err := twilio.SendSMS(params["FROM"], params["TO"], msg, "", "")
 	if err != nil {
 		t.Fatal(err)
@@ -29,7 +30,7 @@ func TestSMS(t *testing.T) {
 
 func TestMMS(t *testing.T) {
 	msg := "Welcome to gotwilio"
-	twilio := NewTwilioClient(params["SID"], params["TOKEN"])
+	twilio := NewTwilioClient(params["SID"], params["TOKEN"], http.DefaultClient)
 	_, exc, err := twilio.SendMMS(params["FROM"], params["TO"], msg, "http://www.google.com/images/logo.png", "", "")
 	if err != nil {
 		t.Fatal(err)
@@ -42,7 +43,7 @@ func TestMMS(t *testing.T) {
 
 func TestVoice(t *testing.T) {
 	callback := NewCallbackParameters("http://example.com")
-	twilio := NewTwilioClient(params["SID"], params["TOKEN"])
+	twilio := NewTwilioClient(params["SID"], params["TOKEN"], http.DefaultClient)
 	_, exc, err := twilio.CallWithUrlCallbacks(params["FROM"], params["TO"], callback)
 	if err != nil {
 		t.Fatal(err)

--- a/gotwilio_test.go
+++ b/gotwilio_test.go
@@ -1,7 +1,6 @@
 package gotwilio
 
 import (
-	"net/http"
 	"testing"
 )
 
@@ -17,7 +16,7 @@ func init() {
 
 func TestSMS(t *testing.T) {
 	msg := "Welcome to gotwilio"
-	twilio := NewTwilioClient(params["SID"], params["TOKEN"], http.DefaultClient)
+	twilio := NewTwilioClient(params["SID"], params["TOKEN"])
 	_, exc, err := twilio.SendSMS(params["FROM"], params["TO"], msg, "", "")
 	if err != nil {
 		t.Fatal(err)
@@ -30,7 +29,7 @@ func TestSMS(t *testing.T) {
 
 func TestMMS(t *testing.T) {
 	msg := "Welcome to gotwilio"
-	twilio := NewTwilioClient(params["SID"], params["TOKEN"], http.DefaultClient)
+	twilio := NewTwilioClient(params["SID"], params["TOKEN"])
 	_, exc, err := twilio.SendMMS(params["FROM"], params["TO"], msg, "http://www.google.com/images/logo.png", "", "")
 	if err != nil {
 		t.Fatal(err)
@@ -43,7 +42,7 @@ func TestMMS(t *testing.T) {
 
 func TestVoice(t *testing.T) {
 	callback := NewCallbackParameters("http://example.com")
-	twilio := NewTwilioClient(params["SID"], params["TOKEN"], http.DefaultClient)
+	twilio := NewTwilioClient(params["SID"], params["TOKEN"])
 	_, exc, err := twilio.CallWithUrlCallbacks(params["FROM"], params["TO"], callback)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Users may setup their http.Client with various useful parameters that are not part of the http.DefaultClient  (importantly including a Timeout). Furthermore, because http.Clients are designed to be reused and are safe across goroutines, sharing a premade http.Client can be beneficial.

If nil is passed in place of an *http.Client, the http.DefaultClient is used.