### PR TITLE
Allow a user SID separate from account SID.

### DIFF
--- a/gotwilio.go
+++ b/gotwilio.go
@@ -11,6 +11,7 @@ import (
 // twilio.com REST api such as AccountSid and AuthToken.
 type Twilio struct {
 	AccountSid string
+	UserSid    string
 	AuthToken  string
 	BaseUrl    string
 	HTTPClient *http.Client
@@ -37,7 +38,7 @@ func NewTwilioClientCustomHTTP(accountSid, authToken string, HTTPClient *http.Cl
 		HTTPClient = http.DefaultClient
 	}
 
-	return &Twilio{accountSid, authToken, twilioUrl, HTTPClient}
+	return &Twilio{accountSid, accountSid, authToken, twilioUrl, HTTPClient}
 }
 
 func (twilio *Twilio) post(formValues url.Values, twilioUrl string) (*http.Response, error) {
@@ -45,7 +46,7 @@ func (twilio *Twilio) post(formValues url.Values, twilioUrl string) (*http.Respo
 	if err != nil {
 		return nil, err
 	}
-	req.SetBasicAuth(twilio.AccountSid, twilio.AuthToken)
+	req.SetBasicAuth(twilio.UserSid, twilio.AuthToken)
 	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 
 	client := twilio.HTTPClient


### PR DESCRIPTION
Twilio lets you generate "API keys" that can be later revoked
programmatically.

[Docs here](https://www.twilio.com/docs/api/rest/keys).

Usage:

``` go
twilio := NewTwilioClient(accountSid, authToken)
twilio.UserSid = "S1234..."
// proceed as normal
```

I avoided creating a `NewTwilioClientWithUser` because, along with the existing `NewTwilioClientCustomHTTP`, seemed like it was heading towards create a combinatorial explosion. It probably makes sense to provided a constructor that takes configuration struct if we to make more client params configurable.

I also couldn't test this directly without having access to the account. I did test manually.
