### PR TITLE
Handle StatusCallbackEvent parameter In Voice calls

### DIFF
--- a/voice.go
+++ b/voice.go
@@ -11,18 +11,19 @@ import (
 // These are the paramters to use when you want Twilio to use callback urls.
 // See http://www.twilio.com/docs/api/rest/making-calls for more info.
 type CallbackParameters struct {
-	Url                     string // Required
-	Method                  string // Optional
-	FallbackUrl             string // Optional
-	FallbackMethod          string // Optional
-	StatusCallback          string // Optional
-	StatusCallbackMethod    string // Optional
-	SendDigits              string // Optional
-	IfMachine               string // False, Continue or Hangup; http://www.twilio.com/docs/errors/21207
-	Timeout                 int    // Optional
-	Record                  bool   // Optional
-	MachineDetection        string // Optional
-	MachineDetectionTimeout int    // Optional
+	Url                     string   // Required
+	Method                  string   // Optional
+	FallbackUrl             string   // Optional
+	FallbackMethod          string   // Optional
+	StatusCallback          string   // Optional
+	StatusCallbackMethod    string   // Optional
+	StatusCallbackEvent     []string // Optional
+	SendDigits              string   // Optional
+	IfMachine               string   // False, Continue or Hangup; http://www.twilio.com/docs/errors/21207
+	Timeout                 int      // Optional
+	Record                  bool     // Optional
+	MachineDetection        string   // Optional
+	MachineDetectionTimeout int      // Optional
 }
 
 // VoiceResponse contains the details about successful voice calls.
@@ -105,6 +106,9 @@ func (twilio *Twilio) CallWithUrlCallbacks(from, to string, callbackParameters *
 	}
 	if callbackParameters.StatusCallbackMethod != "" {
 		formValues.Set("StatusCallbackMethod", callbackParameters.StatusCallbackMethod)
+	}
+	for _, event := range callbackParameters.StatusCallbackEvent {
+		formValues.Add("StatusCallbackEvent", event)
 	}
 	if callbackParameters.SendDigits != "" {
 		formValues.Set("SendDigits", callbackParameters.SendDigits)


### PR DESCRIPTION
Possible values can be `initiated`, `ringing`, `answered` and `completed` (https://www.twilio.com/docs/voice/make-calls#optional-parameters).