### PR TITLE
Use custom http.Client as default client, not http.DefaultClient

### DIFF
--- a/gotwilio.go
+++ b/gotwilio.go
@@ -37,6 +37,10 @@ func NewTwilioClient(accountSid, authToken string) *Twilio {
 
 // Create a new Twilio client, optionally using a custom http.Client
 func NewTwilioClientCustomHTTP(accountSid, authToken string, HTTPClient *http.Client) *Twilio {
+	if HTTPClient == nil {
+		HTTPClient = defaultClient()
+	}
+
 	return &Twilio{accountSid, authToken, baseURL, HTTPClient}
 }
 
@@ -47,8 +51,12 @@ func (twilio *Twilio) post(formValues url.Values, twilioUrl string) (*http.Respo
 	}
 	req.SetBasicAuth(twilio.AccountSid, twilio.AuthToken)
 	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+	client := twilio.HTTPClient
+	if client == nil {
+		client = defaultClient()
+	}
 
-	return twilio.do(req)
+	return client.Do(req)
 }
 
 func (twilio *Twilio) get(twilioUrl string) (*http.Response, error) {
@@ -57,8 +65,12 @@ func (twilio *Twilio) get(twilioUrl string) (*http.Response, error) {
 		return nil, err
 	}
 	req.SetBasicAuth(twilio.AccountSid, twilio.AuthToken)
+	client := twilio.HTTPClient
+	if client == nil {
+		client = defaultClient()
+	}
 
-	return twilio.do(req)
+	return client.Do(req)
 }
 
 func (twilio *Twilio) delete(twilioUrl string) (*http.Response, error) {
@@ -67,11 +79,6 @@ func (twilio *Twilio) delete(twilioUrl string) (*http.Response, error) {
 		return nil, err
 	}
 	req.SetBasicAuth(twilio.AccountSid, twilio.AuthToken)
-
-	return twilio.do(req)
-}
-
-func (twilio *Twilio) do(req *http.Request) (*http.Response, error) {
 	client := twilio.HTTPClient
 	if client == nil {
 		client = defaultClient()

--- a/gotwilio.go
+++ b/gotwilio.go
@@ -5,6 +5,12 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
+)
+
+const (
+	baseURL       = "https://api.twilio.com/2010-04-01"
+	clientTimeout = time.Second * 30
 )
 
 // Twilio stores basic information important for connecting to the
@@ -31,13 +37,7 @@ func NewTwilioClient(accountSid, authToken string) *Twilio {
 
 // Create a new Twilio client, optionally using a custom http.Client
 func NewTwilioClientCustomHTTP(accountSid, authToken string, HTTPClient *http.Client) *Twilio {
-	twilioUrl := "https://api.twilio.com/2010-04-01" // Should this be moved into a constant?
-
-	if HTTPClient == nil {
-		HTTPClient = http.DefaultClient
-	}
-
-	return &Twilio{accountSid, authToken, twilioUrl, HTTPClient}
+	return &Twilio{accountSid, authToken, baseURL, HTTPClient}
 }
 
 func (twilio *Twilio) post(formValues url.Values, twilioUrl string) (*http.Response, error) {
@@ -48,12 +48,7 @@ func (twilio *Twilio) post(formValues url.Values, twilioUrl string) (*http.Respo
 	req.SetBasicAuth(twilio.AccountSid, twilio.AuthToken)
 	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 
-	client := twilio.HTTPClient
-	if client == nil {
-		client = http.DefaultClient
-	}
-
-	return client.Do(req)
+	return twilio.do(req)
 }
 
 func (twilio *Twilio) get(twilioUrl string) (*http.Response, error) {
@@ -63,12 +58,7 @@ func (twilio *Twilio) get(twilioUrl string) (*http.Response, error) {
 	}
 	req.SetBasicAuth(twilio.AccountSid, twilio.AuthToken)
 
-	client := twilio.HTTPClient
-	if client == nil {
-		client = http.DefaultClient
-	}
-
-	return client.Do(req)
+	return twilio.do(req)
 }
 
 func (twilio *Twilio) delete(twilioUrl string) (*http.Response, error) {
@@ -78,10 +68,22 @@ func (twilio *Twilio) delete(twilioUrl string) (*http.Response, error) {
 	}
 	req.SetBasicAuth(twilio.AccountSid, twilio.AuthToken)
 
+	return twilio.do(req)
+}
+
+func (twilio *Twilio) do(req *http.Request) (*http.Response, error) {
 	client := twilio.HTTPClient
 	if client == nil {
-		client = http.DefaultClient
+		client = defaultClient()
 	}
 
 	return client.Do(req)
+}
+
+func defaultClient() *http.Client {
+	client := http.Client{
+		Timeout: clientTimeout,
+	}
+
+	return &client
 }


### PR DESCRIPTION
Hey! As `http.DefaultClient` hasn't timeout by default, better to specify custom `http.Client` with a timeout.