### PR TITLE
Add Video API functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,3 +63,19 @@ To install gotwilio, simply run `go get github.com/sfreiberg/gotwilio`.
 		callbackParams := gotwilio.NewCallbackParameters("http://example.com")
 		twilio.CallWithUrlCallbacks(from, to, callbackParams)
 	}
+
+## Video example
+
+package main
+
+import (
+	"github.com/sfreiberg/gotwilio"
+)
+
+func main() {
+	accountSid := "ABC123..........ABC123"
+	authToken := "ABC123..........ABC123"
+	twilio := gotwilio.NewTwilioClient(accountSid, authToken)
+
+	twilio.CreateVideoRoom(gotwilio.DefaultVideoRoomOptions)
+}

--- a/README.md
+++ b/README.md
@@ -66,16 +66,16 @@ To install gotwilio, simply run `go get github.com/sfreiberg/gotwilio`.
 
 ## Video example
 
-package main
+	package main
 
-import (
-	"github.com/sfreiberg/gotwilio"
-)
+	import (
+		"github.com/sfreiberg/gotwilio"
+	)
 
-func main() {
-	accountSid := "ABC123..........ABC123"
-	authToken := "ABC123..........ABC123"
-	twilio := gotwilio.NewTwilioClient(accountSid, authToken)
+	func main() {
+		accountSid := "ABC123..........ABC123"
+		authToken := "ABC123..........ABC123"
+		twilio := gotwilio.NewTwilioClient(accountSid, authToken)
 
-	twilio.CreateVideoRoom(gotwilio.DefaultVideoRoomOptions)
-}
+		twilio.CreateVideoRoom(gotwilio.DefaultVideoRoomOptions)
+	}

--- a/gotwilio.go
+++ b/gotwilio.go
@@ -10,6 +10,7 @@ import (
 
 const (
 	baseURL       = "https://api.twilio.com/2010-04-01"
+	videoURL      = "https://video.twilio.com"
 	clientTimeout = time.Second * 30
 )
 
@@ -24,6 +25,7 @@ type Twilio struct {
 	AccountSid string
 	AuthToken  string
 	BaseUrl    string
+	VideoUrl   string
 	HTTPClient *http.Client
 }
 
@@ -46,7 +48,7 @@ func NewTwilioClientCustomHTTP(accountSid, authToken string, HTTPClient *http.Cl
 		HTTPClient = defaultClient
 	}
 
-	return &Twilio{accountSid, authToken, baseURL, HTTPClient}
+	return &Twilio{accountSid, authToken, baseURL, videoURL, HTTPClient}
 }
 
 func (twilio *Twilio) post(formValues url.Values, twilioUrl string) (*http.Response, error) {

--- a/video.go
+++ b/video.go
@@ -1,0 +1,150 @@
+package gotwilio
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"time"
+)
+
+// MediaRegion is the locations of Twilio's
+// TURN servers
+type MediaRegion string
+
+const (
+	Australia   MediaRegion = "au1"
+	Brazil      MediaRegion = "br1"
+	Germany     MediaRegion = "de1"
+	Ireland     MediaRegion = "ie1"
+	India       MediaRegion = "in1"
+	Japan       MediaRegion = "jp1"
+	Singapore   MediaRegion = "sg1"
+	USEastCoast MediaRegion = "us1"
+	USWestCoast MediaRegion = "us2"
+)
+
+// VideoStatus is the status of a video room
+type VideoStatus string
+
+const (
+	InProgress VideoStatus = "in-progress"
+	Failed     VideoStatus = "failed"
+	Completed  VideoStatus = "completed"
+)
+
+// VideoRoomType is how the participants connect
+// to each other, whether peer-to-peer of routed
+// through a TURN server.
+type VideoRoomType string
+
+const (
+	PeerToPeer VideoRoomType = "peer-to-peer"
+	Group      VideoRoomType = "group"
+)
+
+// VideoCodecs are the supported codecs when
+// publishing a track to the room.
+type VideoCodecs string
+
+const (
+	VP8  VideoCodecs = "VP8"
+	H264 VideoCodecs = "H264"
+)
+
+// VideoResponse is returned after a room is created
+type VideoResponse struct {
+	AccountSid                  string        `json:"account_sid"`
+	DateCreated                 time.Time     `json:"date_created"`
+	DateUpdated                 time.Time     `json:"date_updated"`
+	Duration                    time.Duration `json:"duration"`
+	EnableTurn                  bool          `json:"enable_turn"`
+	EndTime                     time.Time     `json:"end_time"`
+	MaxParticipants             int64         `json:"max_participants"`
+	MediaRegion                 MediaRegion   `json:"media_region"`
+	RecordParticipantsOnConnect bool          `json:"record_participants_on_connect"`
+	Sid                         string        `json:"sid"`
+	Status                      VideoStatus   `json:"status"`
+	StatusCallback              string        `json:"status_callback"`
+	StatusCallbackMethod        string        `json:"status_callback_method"`
+	Type                        VideoRoomType `json:"type"`
+	UniqueName                  string        `json:"unique_name"`
+	URL                         string        `json:"url"`
+}
+
+type createRoomOptions struct {
+	EnableTurn                  bool          `json:"EnableTurn"`
+	MaxParticipants             int64         `json:"MaxParticipants"`
+	MediaRegion                 MediaRegion   `json:"MediaRegion"`
+	RecordParticipantsOnConnect bool          `json:"RecordParticipantsOnConnect"`
+	StatusCallback              string        `json:"StatusCallback"`
+	StatusCallbackMethod        string        `json:"StatusCallbackMethod"`
+	Type                        VideoRoomType `json:"Type"`
+	UniqueName                  string        `json:"UniqueName"`
+	VideoCodecs                 []VideoCodecs `json:"VideoCodecs"`
+}
+
+// DefaultVideoRoomOptions are the default options
+// for creating a room.
+var DefaultVideoRoomOptions = &createRoomOptions{
+	EnableTurn:                  true,
+	MaxParticipants:             10,
+	MediaRegion:                 USEastCoast,
+	RecordParticipantsOnConnect: false,
+	StatusCallback:              "",
+	StatusCallbackMethod:        http.MethodPost,
+	Type:                        Group,
+	UniqueName:                  "",
+	VideoCodecs:                 []VideoCodecs{H264},
+}
+
+// CreateVideoRoom creates a video communication session
+// for participants to connect to.
+// See https://www.twilio.com/docs/video/api/rooms-resource
+// for more information.
+func (twilio *Twilio) CreateVideoRoom(options *createRoomOptions) (videoResponse *VideoResponse, exception *Exception, err error) {
+	twilioUrl := twilio.VideoUrl + "/v1/Rooms"
+	formValues := createRoomOptionsToFormValues(options)
+
+	res, err := twilio.post(formValues, twilioUrl)
+	if err != nil {
+		return videoResponse, exception, err
+	}
+	defer res.Body.Close()
+
+	responseBody, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return videoResponse, exception, err
+	}
+
+	if res.StatusCode != http.StatusCreated {
+		exception = new(Exception)
+		err = json.Unmarshal(responseBody, exception)
+
+		// We aren't checking the error because we don't actually care.
+		// It's going to be passed to the client either way.
+		return videoResponse, exception, err
+	}
+
+	videoResponse = new(VideoResponse)
+	err = json.Unmarshal(responseBody, videoResponse)
+	return videoResponse, exception, err
+}
+
+func createRoomOptionsToFormValues(options *createRoomOptions) url.Values {
+	formValues := url.Values{}
+	formValues.Set("EnableTurn", fmt.Sprintf("%t", options.EnableTurn))
+	formValues.Set("MaxParticipants", fmt.Sprintf("%d", options.MaxParticipants))
+	formValues.Set("MediaRegion", fmt.Sprintf("%s", options.MediaRegion))
+	formValues.Set("RecordParticipantsOnConnect", fmt.Sprintf("%t", options.RecordParticipantsOnConnect))
+	formValues.Set("StatusCallback", options.StatusCallback)
+	formValues.Set("StatusCallbackMethod", options.StatusCallbackMethod)
+	formValues.Set("Type", fmt.Sprintf("%s", options.Type))
+	formValues.Set("UniqueName", options.UniqueName)
+	formValues.Del("VideoCodecs")
+	for _, codec := range options.VideoCodecs {
+		formValues.Add("VideoCodecs", fmt.Sprintf("%v", codec))
+	}
+	return formValues
+}

--- a/video.go
+++ b/video.go
@@ -132,6 +132,38 @@ func (twilio *Twilio) CreateVideoRoom(options *createRoomOptions) (videoResponse
 	return videoResponse, exception, err
 }
 
+// GetVideoRoom retrievs a single video session
+// by name or by Sid.
+// See https://www.twilio.com/docs/video/api/rooms-resource
+// for more information.
+func (twilio *Twilio) GetVideoRoom(nameOrSid string) (videoResponse *VideoResponse, exception *Exception, err error) {
+	twilioUrl := twilio.VideoUrl + "/v1/Rooms/" + nameOrSid
+
+	res, err := twilio.get(twilioUrl)
+	if err != nil {
+		return videoResponse, exception, err
+	}
+	defer res.Body.Close()
+
+	responseBody, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return videoResponse, exception, err
+	}
+
+	if res.StatusCode != http.StatusOK {
+		exception = new(Exception)
+		err = json.Unmarshal(responseBody, exception)
+
+		// We aren't checking the error because we don't actually care.
+		// It's going to be passed to the client either way.
+		return videoResponse, exception, err
+	}
+
+	videoResponse = new(VideoResponse)
+	err = json.Unmarshal(responseBody, videoResponse)
+	return videoResponse, exception, err
+}
+
 func createRoomOptionsToFormValues(options *createRoomOptions) url.Values {
 	formValues := url.Values{}
 	formValues.Set("EnableTurn", fmt.Sprintf("%t", options.EnableTurn))


### PR DESCRIPTION
I've added enough code to create, list, get and end a video room using the Twilio Video API. There is more video functionality, such as viewing recordings, that isn't included in this update. 

I've tried to keep the style the same as the rest of the project, but had to deviate in a few places because the Video API changes style from the Voice and Message APIs.