### PR TITLE
Add ability to issue JWT Access Tokens

### DIFF
--- a/access_token.go
+++ b/access_token.go
@@ -13,9 +13,9 @@ import (
 // See https://www.twilio.com/docs/iam/access-tokens
 // for further details.
 type AccessToken struct {
-	AccountSid string
-	APIKeySid  string
-	AuthSecret string
+	AccountSid   string
+	APIKeySid    string
+	APIKeySecret string
 
 	NotBefore time.Time
 	ExpiresAt time.Time
@@ -44,9 +44,9 @@ func (g *VideoGrant) grantName() string {
 // for a short period of time.
 func (twilio *Twilio) NewAccessToken() *AccessToken {
 	return &AccessToken{
-		AccountSid: twilio.AccountSid,
-		APIKeySid:  twilio.APIKeySid,
-		AuthSecret: twilio.AuthToken,
+		AccountSid:   twilio.AccountSid,
+		APIKeySid:    twilio.APIKeySid,
+		APIKeySecret: twilio.APIKeySecret,
 	}
 }
 
@@ -56,11 +56,11 @@ func (a *AccessToken) AddGrant(grant Grant) *AccessToken {
 	return a
 }
 
-// Sign the Access Token to provide a JSON Web Token
-// to the user.
+// ToJWT creates a JSON Web Token from the Access Token
+// to use in the Client SDKs.
 // See https://en.wikipedia.org/wiki/JSON_Web_Token
 // for the standard format.
-func (a *AccessToken) Sign() (string, error) {
+func (a *AccessToken) ToJWT() (string, error) {
 	claims := &twilioClaims{
 		jwt.StandardClaims{
 			Id:        a.APIKeySid + fmt.Sprintf("-%d", time.Now().UnixNano()),
@@ -82,7 +82,7 @@ func (a *AccessToken) Sign() (string, error) {
 		"cty": "twilio-fpa;v=1",
 	}
 
-	ss, err := token.SignedString([]byte(a.AuthSecret))
+	ss, err := token.SignedString([]byte(a.APIKeySecret))
 
 	return ss, err
 }

--- a/access_token.go
+++ b/access_token.go
@@ -1,0 +1,109 @@
+package gotwilio
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/dgrijalva/jwt-go"
+)
+
+// AccessToken holds everything required to
+// create authenticate the client SDKs.
+// See https://www.twilio.com/docs/iam/access-tokens
+// for further details.
+type AccessToken struct {
+	AccountSid string
+	APIKeySid  string
+	AuthSecret string
+
+	NotBefore time.Time
+	ExpiresAt time.Time
+	Grants    []Grant
+	Identity  string
+}
+
+// Grant is a perimssion given to the Access Token.
+// Types include Chat, Video etc.
+type Grant interface {
+	grantName() string
+}
+
+// VideoGrant is the permission to use the Video API
+// which can be given to an Access Token.
+type VideoGrant struct {
+	Room string `json:"room,omitempty"`
+}
+
+func (g *VideoGrant) grantName() string {
+	return "video"
+}
+
+// NewAccessToken creates a new Access Token which
+// can be used to authenticate Twilio Client SDKs
+// for a short period of time.
+func (twilio *Twilio) NewAccessToken() *AccessToken {
+	return &AccessToken{
+		AccountSid: twilio.AccountSid,
+		APIKeySid:  twilio.APIKeySid,
+		AuthSecret: twilio.AuthToken,
+	}
+}
+
+// AddGrant adds a given Grant to the Access Token.
+func (a *AccessToken) AddGrant(grant Grant) *AccessToken {
+	a.Grants = append(a.Grants, grant)
+	return a
+}
+
+// Sign the Access Token to provide a JSON Web Token
+// to the user.
+// See https://en.wikipedia.org/wiki/JSON_Web_Token
+// for the standard format.
+func (a *AccessToken) Sign() (string, error) {
+	claims := &twilioClaims{
+		jwt.StandardClaims{
+			Id:        a.APIKeySid + fmt.Sprintf("-%d", time.Now().UnixNano()),
+			Issuer:    a.APIKeySid,
+			Subject:   a.AccountSid,
+			NotBefore: a.NotBefore.Unix(),
+			ExpiresAt: a.ExpiresAt.Unix(),
+		},
+		&grantsClaim{
+			Identity: a.Identity,
+			Grants:   a.Grants,
+		},
+	}
+
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	token.Header = map[string]interface{}{
+		"typ": "JWT",
+		"alg": "HS256",
+		"cty": "twilio-fpa;v=1",
+	}
+
+	ss, err := token.SignedString([]byte(a.AuthSecret))
+
+	return ss, err
+}
+
+// Private helpers to construct the JWT.
+
+type twilioClaims struct {
+	jwt.StandardClaims
+	Grants *grantsClaim `json:"grants"`
+}
+
+type grantsClaim struct {
+	Identity string
+	Grants   []Grant
+}
+
+func (g *grantsClaim) MarshalJSON() ([]byte, error) {
+	data := make(map[string]interface{})
+	data["identity"] = g.Identity
+	for _, grant := range g.Grants {
+		data[grant.grantName()] = grant
+	}
+	return json.Marshal(data)
+}

--- a/gotwilio.go
+++ b/gotwilio.go
@@ -24,10 +24,12 @@ var defaultClient = &http.Client{
 type Twilio struct {
 	AccountSid string
 	AuthToken  string
-	APIKeySid  string
 	BaseUrl    string
 	VideoUrl   string
 	HTTPClient *http.Client
+
+	APIKeySid    string
+	APIKeySecret string
 }
 
 // Exception is a representation of a twilio exception.
@@ -56,6 +58,12 @@ func NewTwilioClientCustomHTTP(accountSid, authToken string, HTTPClient *http.Cl
 		VideoUrl:   videoURL,
 		HTTPClient: HTTPClient,
 	}
+}
+
+func (twilio *Twilio) WithAPIKey(apiKeySid string, apiKeySecret string) *Twilio {
+	twilio.APIKeySid = apiKeySid
+	twilio.APIKeySecret = apiKeySecret
+	return twilio
 }
 
 func (twilio *Twilio) post(formValues url.Values, twilioUrl string) (*http.Response, error) {

--- a/gotwilio.go
+++ b/gotwilio.go
@@ -24,6 +24,7 @@ var defaultClient = &http.Client{
 type Twilio struct {
 	AccountSid string
 	AuthToken  string
+	APIKeySid  string
 	BaseUrl    string
 	VideoUrl   string
 	HTTPClient *http.Client
@@ -48,7 +49,13 @@ func NewTwilioClientCustomHTTP(accountSid, authToken string, HTTPClient *http.Cl
 		HTTPClient = defaultClient
 	}
 
-	return &Twilio{accountSid, authToken, baseURL, videoURL, HTTPClient}
+	return &Twilio{
+		AccountSid: accountSid,
+		AuthToken:  authToken,
+		BaseUrl:    baseURL,
+		VideoUrl:   videoURL,
+		HTTPClient: HTTPClient,
+	}
 }
 
 func (twilio *Twilio) post(formValues url.Values, twilioUrl string) (*http.Response, error) {


### PR DESCRIPTION
This change adds the ability to issue an access token for a user to authenticate against the Twilio Client SDKs. There are grants to give permissions for using Video, Chat, Voice, etc. This pull request only implements the Video grant, but provides an easily extensible structure for adding any number of grants. 

~~The only slightly inelegance is the change to the Twilio struct, which now requires a `APIKeySid` property. This breaks the constructor functions (e.g. `NewTwilioClientCustomHTTP`) but I've kept backwards compatibility. More thought needs to be given to how we can ensure the `APIKeySid` is set. This works for now I think.~~

I've made it so you can provide an API Key and Secret to the Twilio Client for use when creating Access Tokens. It might be an idea to extend this in future to provide several named API keys for generating Access Tokens for multiple applications.

Example use:

	twilio := gotwilio.NewTwilioClient(accountSid, authToken).WithAPIKey(apiKey, apiSecret)

	a := twilio.NewAccessToken()
	a.Identity = "Josh"
	a.NotBefore = time.Now()
	a.ExpiresAt = time.Now().Add(time.Hour * 24)
	a.Grants = []gotwilio.Grant{
		&gotwilio.VideoGrant{
			Room: "testing-room",
		},
	}
	s, _ := a.ToJWT()
	fmt.Println(s)

