### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/fax.go
+++ b/fax.go
@@ -15,13 +15,13 @@ type FaxBase struct {
 	DateUpdated string `json:"date_updated"`
 }
 
-// Returns FaxBase.DateCreated as a time.Time object
+// DateCreatedAsTime returns FaxBase.DateCreated as a time.Time object
 // instead of a string.
 func (d *FaxBase) DateCreatedAsTime() (time.Time, error) {
 	return time.Parse(time.RFC1123Z, d.DateCreated)
 }
 
-// Returns FaxBase.DateUpdated as a time.Time object
+// DateUpdatesAsTime returns FaxBase.DateUpdated as a time.Time object
 // instead of a string.
 func (d *FaxBase) DateUpdatesAsTime() (time.Time, error) {
 	return time.Parse(time.RFC1123Z, d.DateUpdated)

--- a/proxy_participant.go
+++ b/proxy_participant.go
@@ -85,7 +85,7 @@ type ProxyMessage struct {
 	Callback string // Webhook url to handle processed record.
 }
 
-// Add Participant to Session
+// AddParticipant adds Participant to Session
 func (session *ProxySession) AddParticipant(req ParticipantRequest) (response Participant, exception *Exception, err error) {
 
 	twilioUrl := fmt.Sprintf("%s/%s/%s/%s/%s/%s", ProxyBaseUrl, "Services", session.ServiceSid, "Sessions", session.Sid, "Participants")

--- a/sms.go
+++ b/sms.go
@@ -26,25 +26,25 @@ type SmsResponse struct {
 	Url         string  `json:"uri"`
 }
 
-// Returns SmsResponse.DateCreated as a time.Time object
+// DateCreatedAsTime returns SmsResponse.DateCreated as a time.Time object
 // instead of a string.
 func (sms *SmsResponse) DateCreatedAsTime() (time.Time, error) {
 	return time.Parse(time.RFC1123Z, sms.DateCreated)
 }
 
-// Returns SmsResponse.DateUpdate as a time.Time object
+// DateUpdateAsTime returns SmsResponse.DateUpdate as a time.Time object
 // instead of a string.
 func (sms *SmsResponse) DateUpdateAsTime() (time.Time, error) {
 	return time.Parse(time.RFC1123Z, sms.DateUpdate)
 }
 
-// Returns SmsResponse.DateSent as a time.Time object
+// DateSentAsTime returns SmsResponse.DateSent as a time.Time object
 // instead of a string.
 func (sms *SmsResponse) DateSentAsTime() (time.Time, error) {
 	return time.Parse(time.RFC1123Z, sms.DateSent)
 }
 
-// SendTextMessage uses Twilio to send a text message.
+// SendSMS uses Twilio to send a text message.
 // See http://www.twilio.com/docs/api/rest/sending-sms for more information.
 func (twilio *Twilio) SendSMS(from, to, body, statusCallback, applicationSid string) (smsResponse *SmsResponse, exception *Exception, err error) {
 	formValues := initFormValues(to, body, "", statusCallback, applicationSid)
@@ -94,7 +94,7 @@ func (twilio *Twilio) SendSMSWithCopilot(messagingServiceSid, to, body, statusCa
 	return
 }
 
-// SendMultimediaMessage uses Twilio to send a multimedia message.
+// SendMMS uses Twilio to send a multimedia message.
 func (twilio *Twilio) SendMMS(from, to, body, mediaUrl, statusCallback, applicationSid string) (smsResponse *SmsResponse, exception *Exception, err error) {
 	formValues := initFormValues(to, body, mediaUrl, statusCallback, applicationSid)
 	formValues.Set("From", from)

--- a/voice.go
+++ b/voice.go
@@ -60,31 +60,31 @@ type VoiceResponse struct {
 	// TODO: handle price_unit
 }
 
-// Returns VoiceResponse.DateCreated as a time.Time object
+// DateCreatedAsTime returns VoiceResponse.DateCreated as a time.Time object
 // instead of a string.
 func (vr *VoiceResponse) DateCreatedAsTime() (time.Time, error) {
 	return time.Parse(time.RFC1123Z, vr.DateCreated)
 }
 
-// Returns VoiceResponse.DateUpdated as a time.Time object
+// DateUpdatedAsTime returns VoiceResponse.DateUpdated as a time.Time object
 // instead of a string.
 func (vr *VoiceResponse) DateUpdatedAsTime() (time.Time, error) {
 	return time.Parse(time.RFC1123Z, vr.DateUpdated)
 }
 
-// Returns VoiceResponse.StartTime as a time.Time object
+// StartTimeAsTime returns VoiceResponse.StartTime as a time.Time object
 // instead of a string.
 func (vr *VoiceResponse) StartTimeAsTime() (time.Time, error) {
 	return time.Parse(time.RFC1123Z, vr.StartTime)
 }
 
-// Returns VoiceResponse.EndTime as a time.Time object
+// EndTimeAsTime returns VoiceResponse.EndTime as a time.Time object
 // instead of a string.
 func (vr *VoiceResponse) EndTimeAsTime() (time.Time, error) {
 	return time.Parse(time.RFC1123Z, vr.EndTime)
 }
 
-// Returns a CallbackParameters type with the specified url and
+// NewCallbackParameters returns a CallbackParameters type with the specified url and
 // CallbackParameters.Timeout set to 60.
 func NewCallbackParameters(url string) *CallbackParameters {
 	return &CallbackParameters{Url: url, Timeout: 60}


### PR DESCRIPTION
Hi, we updated some exported function comments based on best practices from [Effective Go](https://golang.org/doc/effective_go.html#commentary). It’s admittedly a relatively minor fix up. Does this help you?