### PR TITLE
Remove extraneous log

### DIFF
--- a/lookup.go
+++ b/lookup.go
@@ -40,7 +40,6 @@ func (twilio *Twilio) SubmitLookup(req LookupReq) (Lookup, error) {
 	if err := encoder.Encode(req, values); err != nil {
 		return Lookup{}, err
 	}
-	fmt.Println(req)
 
 	url := fmt.Sprintf("%s/PhoneNumbers/%s?%s", twilio.LookupURL, req.PhoneNumber, values.Encode())
 	res := Lookup{}


### PR DESCRIPTION
The `req` struct includes PII (phone number), and cannot be disabled. If logging is needed sometimes – perhaps it can be made conditional, otherwise I believe it's best to remove it.