### PR TITLE
Fax: Use integers rather than strings

### DIFF
--- a/fax.go
+++ b/fax.go
@@ -39,8 +39,8 @@ type FaxResource struct {
 	From       string  `json:"from"`
 	To         string  `json:"to"`
 	Direction  string  `json:"direction"`
-	NumPages   uint    `json:"num_pages,string"`
-	Duration   uint    `json:"duration,string"`
+	NumPages   uint    `json:"num_pages"`
+	Duration   uint    `json:"duration"`
 	MediaSid   string  `json:"media_sid"`
 	MediaUrl   string  `json:"media_url"`
 	Status     string  `json:"status"`


### PR DESCRIPTION
Both `num_pages` and `duration` are returned from Twilio as integers, so when looking up a fax using `GetFax`, unmarshaling causes 
```
panic: json: invalid use of ,string struct tag, trying to unmarshal unquoted value into uint
```