### PR TITLE
Add MMS with Copilot (with multiple mediaUrls)

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ To install gotwilio, simply run `go get github.com/sfreiberg/gotwilio`.
 		from := "+15555555555"
 		to := "+15555555555"
 		message := "Welcome to gotwilio!"
-		twilio.SendMMS(from, to, message, "http://host/myimage.gif", "", "")
+		mediaUrl := []string{"http://host/myimage.gif"}
+		twilio.SendMMS(from, to, message, mediaUrl, "", "")
 	}
 
 ## Voice Example

--- a/gotwilio_test.go
+++ b/gotwilio_test.go
@@ -57,6 +57,24 @@ func TestMMSMultipleFiles(t *testing.T) {
 	}
 }
 
+func TestMMSTooManyFiles(t *testing.T) {
+	msg := "Welcome to gotwilio"
+	twilio := NewTwilioClient(params["SID"], params["TOKEN"])
+	var files []string
+	for i := 0; i < 11; i++ {
+		files = append(files, "http://www.google.com/images/logo.png")
+	}
+	_, exc, err := twilio.SendMMS(params["FROM"], params["TO"], msg, files, "", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Test for code for too many files
+	if exc == nil || int(exc.Code) != 21623 {
+		t.Fatal(exc)
+	}
+}
+
 func TestVoice(t *testing.T) {
 	callback := NewCallbackParameters("http://example.com")
 	twilio := NewTwilioClient(params["SID"], params["TOKEN"])

--- a/gotwilio_test.go
+++ b/gotwilio_test.go
@@ -43,6 +43,20 @@ func TestMMS(t *testing.T) {
 	}
 }
 
+func TestMMSMultipleFiles(t *testing.T) {
+	msg := "Welcome to gotwilio"
+	twilio := NewTwilioClient(params["SID"], params["TOKEN"])
+	files := []string{"http://www.google.com/images/logo.png", "http://www.google.com/images/logo.png"}
+	_, exc, err := twilio.SendMMS(params["FROM"], params["TO"], msg, files, "", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if exc != nil {
+		t.Fatal(exc)
+	}
+}
+
 func TestVoice(t *testing.T) {
 	callback := NewCallbackParameters("http://example.com")
 	twilio := NewTwilioClient(params["SID"], params["TOKEN"])

--- a/gotwilio_test.go
+++ b/gotwilio_test.go
@@ -33,7 +33,7 @@ func TestSMS(t *testing.T) {
 func TestMMS(t *testing.T) {
 	msg := "Welcome to gotwilio"
 	twilio := NewTwilioClient(params["SID"], params["TOKEN"])
-	file := []string{"http://www.google.com/images/logo.png"}
+	file := []string{"https://www.google.com/images/logo.png"}
 	_, exc, err := twilio.SendMMS(params["FROM"], params["TO"], msg, file, "", "")
 	if err != nil {
 		t.Fatal(err)
@@ -47,7 +47,7 @@ func TestMMS(t *testing.T) {
 func TestMMSMultipleFiles(t *testing.T) {
 	msg := "Welcome to gotwilio"
 	twilio := NewTwilioClient(params["SID"], params["TOKEN"])
-	files := []string{"http://www.google.com/images/logo.png", "http://www.google.com/images/logo.png"}
+	files := []string{"https://www.google.com/images/logo.png", "https://www.google.com/images/logo.png"}
 	_, exc, err := twilio.SendMMS(params["FROM"], params["TO"], msg, files, "", "")
 	if err != nil {
 		t.Fatal(err)
@@ -63,7 +63,7 @@ func TestMMSTooManyFiles(t *testing.T) {
 	twilio := NewTwilioClient(params["SID"], params["TOKEN"])
 	var files []string
 	for i := 0; i < 11; i++ {
-		files = append(files, "http://www.google.com/images/logo.png")
+		files = append(files, "https://www.google.com/images/logo.png")
 	}
 	_, exc, err := twilio.SendMMS(params["FROM"], params["TO"], msg, files, "", "")
 	if err != nil {

--- a/gotwilio_test.go
+++ b/gotwilio_test.go
@@ -33,7 +33,8 @@ func TestSMS(t *testing.T) {
 func TestMMS(t *testing.T) {
 	msg := "Welcome to gotwilio"
 	twilio := NewTwilioClient(params["SID"], params["TOKEN"])
-	_, exc, err := twilio.SendMMS(params["FROM"], params["TO"], msg, "http://www.google.com/images/logo.png", "", "")
+	file := []string{"http://www.google.com/images/logo.png"}
+	_, exc, err := twilio.SendMMS(params["FROM"], params["TO"], msg, file, "", "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/sms.go
+++ b/sms.go
@@ -113,6 +113,16 @@ func (twilio *Twilio) SendMMS(from, to, body, mediaUrl, statusCallback, applicat
 	return
 }
 
+// SendMMSWithCopilot uses Twilio Copilot to send a multimedia message.
+// See https://www.twilio.com/docs/api/rest/sending-messages-copilot
+func (twilio *Twilio) SendMMSWithCopilot(messagingServiceSid, to, body, mediaUrl, statusCallback, applicationSid string) (smsResponse *SmsResponse, exception *Exception, err error) {
+	formValues := initFormValues(to, body, mediaUrl, statusCallback, applicationSid)
+	formValues.Set("MessagingServiceSid", messagingServiceSid)
+
+	smsResponse, exception, err = twilio.sendMessage(formValues)
+	return
+}
+
 // Core method to send message
 func (twilio *Twilio) sendMessage(formValues url.Values) (smsResponse *SmsResponse, exception *Exception, err error) {
 	twilioUrl := twilio.BaseUrl + "/Accounts/" + twilio.AccountSid + "/Messages.json"

--- a/sms.go
+++ b/sms.go
@@ -57,7 +57,7 @@ func (twilio *Twilio) SendWhatsApp(from, to, body, statusCallback, applicationSi
 // SendSMS uses Twilio to send a text message.
 // See http://www.twilio.com/docs/api/rest/sending-sms for more information.
 func (twilio *Twilio) SendSMS(from, to, body, statusCallback, applicationSid string) (smsResponse *SmsResponse, exception *Exception, err error) {
-	formValues := initFormValues(to, body, "", statusCallback, applicationSid)
+	formValues := initFormValues(to, body, nil, statusCallback, applicationSid)
 	formValues.Set("From", from)
 
 	smsResponse, exception, err = twilio.sendMessage(formValues)
@@ -97,7 +97,7 @@ func (twilio *Twilio) GetSMS(sid string) (smsResponse *SmsResponse, exception *E
 // SendSMSWithCopilot uses Twilio Copilot to send a text message.
 // See https://www.twilio.com/docs/api/rest/sending-messages-copilot
 func (twilio *Twilio) SendSMSWithCopilot(messagingServiceSid, to, body, statusCallback, applicationSid string) (smsResponse *SmsResponse, exception *Exception, err error) {
-	formValues := initFormValues(to, body, "", statusCallback, applicationSid)
+	formValues := initFormValues(to, body, nil, statusCallback, applicationSid)
 	formValues.Set("MessagingServiceSid", messagingServiceSid)
 
 	smsResponse, exception, err = twilio.sendMessage(formValues)
@@ -105,7 +105,7 @@ func (twilio *Twilio) SendSMSWithCopilot(messagingServiceSid, to, body, statusCa
 }
 
 // SendMMS uses Twilio to send a multimedia message.
-func (twilio *Twilio) SendMMS(from, to, body string, mediaUrl interface{}, statusCallback, applicationSid string) (smsResponse *SmsResponse, exception *Exception, err error) {
+func (twilio *Twilio) SendMMS(from, to, body string, mediaUrl []string, statusCallback, applicationSid string) (smsResponse *SmsResponse, exception *Exception, err error) {
 	formValues := initFormValues(to, body, mediaUrl, statusCallback, applicationSid)
 	formValues.Set("From", from)
 
@@ -115,7 +115,7 @@ func (twilio *Twilio) SendMMS(from, to, body string, mediaUrl interface{}, statu
 
 // SendMMSWithCopilot uses Twilio Copilot to send a multimedia message.
 // See https://www.twilio.com/docs/api/rest/sending-messages-copilot
-func (twilio *Twilio) SendMMSWithCopilot(messagingServiceSid, to, body string, mediaUrl interface{}, statusCallback, applicationSid string) (smsResponse *SmsResponse, exception *Exception, err error) {
+func (twilio *Twilio) SendMMSWithCopilot(messagingServiceSid, to, body string, mediaUrl []string, statusCallback, applicationSid string) (smsResponse *SmsResponse, exception *Exception, err error) {
 	formValues := initFormValues(to, body, mediaUrl, statusCallback, applicationSid)
 	formValues.Set("MessagingServiceSid", messagingServiceSid)
 
@@ -153,22 +153,15 @@ func (twilio *Twilio) sendMessage(formValues url.Values) (smsResponse *SmsRespon
 }
 
 // Form values initialization
-func initFormValues(to, body string, mediaUrl interface{}, statusCallback, applicationSid string) url.Values {
+func initFormValues(to, body string, mediaUrl []string, statusCallback, applicationSid string) url.Values {
 	formValues := url.Values{}
 
 	formValues.Set("To", to)
 	formValues.Set("Body", body)
 
-	switch m := mediaUrl.(type) {
-	case string:
-		if m != ""{
-			formValues.Set("MediaUrl", m)
-		}
-	case []string:
-		if len(m) > 0 {
-			for _, value := range m {
-				formValues.Add("MediaUrl", value)
-			}
+	if len(mediaUrl) > 0 {
+		for _, value := range mediaUrl {
+			formValues.Add("MediaUrl", value)
 		}
 	}
 

--- a/sms.go
+++ b/sms.go
@@ -17,7 +17,6 @@ type SmsResponse struct {
 	AccountSid  string  `json:"account_sid"`
 	To          string  `json:"to"`
 	From        string  `json:"from"`
-	MediaUrl    string  `json:"media_url"`
 	NumMedia    string  `json:"num_media"`
 	Body        string  `json:"body"`
 	Status      string  `json:"status"`

--- a/sms.go
+++ b/sms.go
@@ -18,6 +18,7 @@ type SmsResponse struct {
 	To          string  `json:"to"`
 	From        string  `json:"from"`
 	MediaUrl    string  `json:"media_url"`
+	NumMedia    string  `json:"num_media"`
 	Body        string  `json:"body"`
 	Status      string  `json:"status"`
 	Direction   string  `json:"direction"`
@@ -105,7 +106,7 @@ func (twilio *Twilio) SendSMSWithCopilot(messagingServiceSid, to, body, statusCa
 }
 
 // SendMMS uses Twilio to send a multimedia message.
-func (twilio *Twilio) SendMMS(from, to, body, mediaUrl, statusCallback, applicationSid string) (smsResponse *SmsResponse, exception *Exception, err error) {
+func (twilio *Twilio) SendMMS(from, to, body string, mediaUrl interface{}, statusCallback, applicationSid string) (smsResponse *SmsResponse, exception *Exception, err error) {
 	formValues := initFormValues(to, body, mediaUrl, statusCallback, applicationSid)
 	formValues.Set("From", from)
 
@@ -115,7 +116,7 @@ func (twilio *Twilio) SendMMS(from, to, body, mediaUrl, statusCallback, applicat
 
 // SendMMSWithCopilot uses Twilio Copilot to send a multimedia message.
 // See https://www.twilio.com/docs/api/rest/sending-messages-copilot
-func (twilio *Twilio) SendMMSWithCopilot(messagingServiceSid, to, body, mediaUrl, statusCallback, applicationSid string) (smsResponse *SmsResponse, exception *Exception, err error) {
+func (twilio *Twilio) SendMMSWithCopilot(messagingServiceSid, to, body string, mediaUrl interface{}, statusCallback, applicationSid string) (smsResponse *SmsResponse, exception *Exception, err error) {
 	formValues := initFormValues(to, body, mediaUrl, statusCallback, applicationSid)
 	formValues.Set("MessagingServiceSid", messagingServiceSid)
 
@@ -153,14 +154,23 @@ func (twilio *Twilio) sendMessage(formValues url.Values) (smsResponse *SmsRespon
 }
 
 // Form values initialization
-func initFormValues(to, body, mediaUrl, statusCallback, applicationSid string) url.Values {
+func initFormValues(to, body string, mediaUrl interface{}, statusCallback, applicationSid string) url.Values {
 	formValues := url.Values{}
 
 	formValues.Set("To", to)
 	formValues.Set("Body", body)
 
-	if mediaUrl != "" {
-		formValues.Set("MediaUrl", mediaUrl)
+	switch m := mediaUrl.(type) {
+	case string:
+		if m != ""{
+			formValues.Set("MediaUrl", m)
+		}
+	case []string:
+		if len(m) > 0 {
+			for _, value := range m {
+				formValues.Add("MediaUrl", value)
+			}
+		}
 	}
 
 	if statusCallback != "" {


### PR DESCRIPTION
This is related to the issue that I opened up here: https://github.com/sfreiberg/gotwilio/issues/68

I'd like to add support for sending multimedia messages over Twilio's Copilot. Unfortunately, gotwilio does not support this path right now. This PR attempts to add support for that, while also adding support for multiple `mediaUrl` params, which Twilio allows (up to 10--I decided not to check this and let Twilio enforce this, but happy to change).

**Breaking change:** I modified the signature of `SendMMS` to only accept a string slice for `mediaUrl`. I did this to conform with the other twilio SDKs, which all do this as well: https://www.twilio.com/docs/sms/send-messages?code-sample=code-send-an-mms-message&code-language=Node.js&code-sdk-version=3.x
This makes it so we don't have to do type checking to see if the parameter is a string or string slice (I previously implemented this way using `interface{}` but decided to simplify it to make it more in-line with other language SDKs)

**One more breaking change:** I removed `MediaUrl` from the `SmsResponse` since I don't believe this field exists. I added `NumMedia` as this is now more relevant because a user can now send multiple media files. (Reference: https://www.twilio.com/docs/sms/send-messages?code-sample=code-send-an-sms-message&code-language=curl&code-sdk-version=json)

Unfortunately, I couldn't figure out how to unit test copilot (@sfreiberg, do you have a test `messagingServiceSid` that we could use in the unit tests?). That said, I was at least able to test the multiple `mediaUrl` params through the regular `SendMMS` function.