### PR TITLE
Added SendWhatsAppMedia method

### DIFF
--- a/gotwilio_test.go
+++ b/gotwilio_test.go
@@ -15,6 +15,11 @@ func init() {
 	params["TOKEN"] = "1dcf52d7a1f3853ed78f0ee20d056dd0"
 	params["FROM"] = "+15005550006"
 	params["TO"] = "+19135551234"
+	params["WHATSAPP"] = "" // if empty, will skip WhatsApp tests
+	// setup a WhatsApp sandbox in the Twilio console
+	// and add the setup the WHATSAPP_FROM adn WHATSAPP_TO numbers
+	params["WHATSAPP_FROM"] = ""
+	params["WHATSAPP_TO"] = ""
 }
 
 func TestSMS(t *testing.T) {
@@ -72,6 +77,43 @@ func TestMMSTooManyFiles(t *testing.T) {
 
 	// Test for code for too many files
 	if exc == nil || int(exc.Code) != 21623 {
+		t.Fatal(exc)
+	}
+}
+
+func TestWhatsApp(t *testing.T) {
+	if len(params["WHATSAPP"]) == 0 {
+		t.Skip("skipping WhatsApp test")
+	}
+
+	msg := "Welcome to gotwilio from WhatsApp"
+	twilio := NewTwilioClient(params["SID"], params["TOKEN"])
+	_, exc, err := twilio.SendWhatsApp(params["WHATSAPP_FROM"], params["WHATSAPP_TO"], msg, "", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if exc != nil {
+		t.Fatal(exc)
+	}
+}
+
+func TestWhatsAppMedia(t *testing.T) {
+	if len(params["WHATSAPP"]) == 0 {
+		t.Skip("skipping WhatsApp test")
+	}
+
+	msg := "Welcome to gotwilio from WhatsApp Media, here's a cute cat picture"
+	twilio := NewTwilioClient(params["SID"], params["TOKEN"])
+	file := []string{
+		"https://bit.ly/3bZY1oV", // cute cat photo
+	}
+	_, exc, err := twilio.SendWhatsAppMedia(params["WHATSAPP_FROM"], params["WHATSAPP_TO"], msg, file, "", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if exc != nil {
 		t.Fatal(exc)
 	}
 }

--- a/sms.go
+++ b/sms.go
@@ -54,6 +54,15 @@ func (twilio *Twilio) SendWhatsApp(from, to, body, statusCallback, applicationSi
 	return twilio.SendSMS(whatsapp(from), whatsapp(to), body, statusCallback, applicationSid)
 }
 
+// SendWhatsAppMedia uses Twilio to send a WhatsApp message with Media enabled.
+// See https://www.twilio.com/docs/sms/whatsapp/tutorial/send-and-receive-media-messages-whatsapp-python
+func (twilio *Twilio) SendWhatsAppMedia(from, to, body string, mediaURL []string, statusCallback, applicationSid string) (smsResponse *SmsResponse, exception *Exception, err error) {
+	formValues := initFormValues(whatsapp(to), body, mediaURL, statusCallback, applicationSid)
+	formValues.Set("From", whatsapp(from))
+
+	return twilio.sendMessage(formValues)
+}
+
 // SendSMS uses Twilio to send a text message.
 // See http://www.twilio.com/docs/api/rest/sending-sms for more information.
 func (twilio *Twilio) SendSMS(from, to, body, statusCallback, applicationSid string) (smsResponse *SmsResponse, exception *Exception, err error) {


### PR DESCRIPTION
I created issue #71 and decided to implement it right away. I added the following changes:

- Implemented the method `SendWhatsAppMedia` in sms.go.
- Added WhatApp methods (`SendWhatsApp` and `SendWhatsAppMedia`) tests in gotwilio_test.go. Note that to run the tests I added a few fields to the `params` variable. By default the tests are skipped, you have to set up a Sandbox from the WhatsApp API in the Twilio Console and then set up the `WHATSAPP_FROM` and `WHATSAPP_TO` fields. Finally set the `WHATSAPP` parameter to any no empty string.