### PR TITLE
Added 'caller_name' support to lookup

### DIFF
--- a/lookup.go
+++ b/lookup.go
@@ -3,8 +3,14 @@ package gotwilio
 import (
 	"fmt"
 	"net/url"
+	"strings"
 
 	"github.com/gorilla/schema"
+)
+
+const (
+	// LookupTypeString format for rquest type
+	LookupTypeString = "Type"
 )
 
 // LookupReq Go-representation of Twilio REST API's lookup request.
@@ -46,7 +52,19 @@ func (twilio *Twilio) SubmitLookup(req LookupReq) (Lookup, error) {
 		return Lookup{}, err
 	}
 
-	url := fmt.Sprintf("%s/PhoneNumbers/%s?%s", twilio.LookupURL, req.PhoneNumber, values.Encode())
+	// check for multiple types
+	var types string
+	for _, t := range strings.Split(values.Get(LookupTypeString), ",") {
+		types += fmt.Sprintf("%s=%s&", LookupTypeString, strings.TrimSpace(t))
+	}
+
+	// remove trailing '&'
+	types = strings.TrimRight(types, "&")
+
+	// remove req.Type value
+	values.Del(LookupTypeString)
+
+	url := fmt.Sprintf("%s/PhoneNumbers/%s?%s&%s", twilio.LookupURL, req.PhoneNumber, values.Encode(), types)
 	res := Lookup{}
 	err := twilio.getJSON(url, &res)
 	return res, err

--- a/lookup.go
+++ b/lookup.go
@@ -9,8 +9,11 @@ import (
 )
 
 const (
-	// LookupTypeString format for rquest type
+	// LookupTypeString format for single request type
 	LookupTypeString = "Type"
+
+	// LookupTypesString format for multiple request types
+	LookupTypesString = "Types"
 )
 
 // LookupReq Go-representation of Twilio REST API's lookup request.
@@ -18,6 +21,7 @@ const (
 type LookupReq struct {
 	PhoneNumber string
 	Type        string
+	Types       []string
 	CountryCode string
 }
 
@@ -54,15 +58,16 @@ func (twilio *Twilio) SubmitLookup(req LookupReq) (Lookup, error) {
 
 	// check for multiple types
 	var types string
-	for _, t := range strings.Split(values.Get(LookupTypeString), ",") {
-		types += fmt.Sprintf("%s=%s&", LookupTypeString, strings.TrimSpace(t))
+	if len(req.Types) > 0 {
+		types = fmt.Sprintf("%s=%s", LookupTypeString, strings.Join(req.Types, "&Type="))
+		values.Del(LookupTypeString)
+	} else {
+		types = fmt.Sprintf("%s=%s", LookupTypeString, values.Get(LookupTypeString))
 	}
-
-	// remove trailing '&'
-	types = strings.TrimRight(types, "&")
 
 	// remove req.Type value
 	values.Del(LookupTypeString)
+	values.Del(LookupTypesString)
 
 	url := fmt.Sprintf("%s/PhoneNumbers/%s?%s&%s", twilio.LookupURL, req.PhoneNumber, values.Encode(), types)
 	res := Lookup{}

--- a/lookup.go
+++ b/lookup.go
@@ -60,7 +60,6 @@ func (twilio *Twilio) SubmitLookup(req LookupReq) (Lookup, error) {
 	var types string
 	if len(req.Types) > 0 {
 		types = fmt.Sprintf("%s=%s", LookupTypeString, strings.Join(req.Types, "&Type="))
-		values.Del(LookupTypeString)
 	} else {
 		types = fmt.Sprintf("%s=%s", LookupTypeString, values.Get(LookupTypeString))
 	}

--- a/lookup.go
+++ b/lookup.go
@@ -18,6 +18,11 @@ type LookupReq struct {
 // Lookup Go-representation of Twilio REST API's lookup.
 // https://www.twilio.com/docs/api/rest/lookups
 type Lookup struct {
+	CallerName *struct {
+		ErrorCode  *int   `json:"error_code"`
+		CallerName string `json:"caller_name"`
+		CallerType string `json:"caller_type"`
+	} `json:"caller_name"`
 	Carrier *struct {
 		ErrorCode         *int   `json:"error_code"`
 		MobileCountryCode string `json:"mobile_country_code"`

--- a/lookup_test.go
+++ b/lookup_test.go
@@ -31,7 +31,11 @@ func TestLookup(t *testing.T) {
 // Example from https://www.twilio.com/docs/usage/api/usage-record:
 const testLookupResponse = `
 {
-	"caller_name": null,
+	"caller_name": {
+		"error_code": null,
+		"caller_name": "My Business, INC",
+		"caller_type": "CONSUMER",
+	},
 	"carrier": {
 	  "error_code": null,
 	  "mobile_country_code": "310",

--- a/lookup_test.go
+++ b/lookup_test.go
@@ -64,7 +64,7 @@ func TestLookupMultipleTypes(t *testing.T) {
 	twilio.LookupURL = srv.URL
 	req := &LookupReq{
 		PhoneNumber: "+11231231234",
-		Type:        "carrier,caller-name",
+		Types:       []string{"carrier", "caller-name"},
 	}
 	lookup, err := twilio.SubmitLookup(*req)
 	if err != nil {

--- a/lookup_test.go
+++ b/lookup_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 )
 
-func TestLookup(t *testing.T) {
+func TestLookupCarrier(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintf(w, testLookupResponse)
 	}))
@@ -16,7 +16,56 @@ func TestLookup(t *testing.T) {
 
 	twilio := NewTwilioClient("", "")
 	twilio.LookupURL = srv.URL
-	req := &LookupReq{PhoneNumber: "+11231231234"}
+	req := &LookupReq{
+		PhoneNumber: "+11231231234",
+		Type:        "carrier",
+	}
+	lookup, err := twilio.SubmitLookup(*req)
+	if err != nil {
+		t.Fatalf("Failed: %s", err.Error())
+	}
+	bs, err := json.MarshalIndent(lookup, "", "  ")
+	if err != nil {
+		t.Fatalf("Failed: %s", err.Error())
+	}
+	t.Logf("Lookup Result:\n%s\n", string(bs))
+}
+
+func TestLookupCallerName(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, testLookupResponse)
+	}))
+	defer srv.Close()
+
+	twilio := NewTwilioClient("", "")
+	twilio.LookupURL = srv.URL
+	req := &LookupReq{
+		PhoneNumber: "+11231231234",
+		Type:        "caller-name",
+	}
+	lookup, err := twilio.SubmitLookup(*req)
+	if err != nil {
+		t.Fatalf("Failed: %s", err.Error())
+	}
+	bs, err := json.MarshalIndent(lookup, "", "  ")
+	if err != nil {
+		t.Fatalf("Failed: %s", err.Error())
+	}
+	t.Logf("Lookup Result:\n%s\n", string(bs))
+}
+
+func TestLookupMultipleTypes(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, testLookupResponse)
+	}))
+	defer srv.Close()
+
+	twilio := NewTwilioClient("", "")
+	twilio.LookupURL = srv.URL
+	req := &LookupReq{
+		PhoneNumber: "+11231231234",
+		Type:        "carrier,caller-name",
+	}
 	lookup, err := twilio.SubmitLookup(*req)
 	if err != nil {
 		t.Fatalf("Failed: %s", err.Error())
@@ -31,23 +80,23 @@ func TestLookup(t *testing.T) {
 // Example from https://www.twilio.com/docs/usage/api/usage-record:
 const testLookupResponse = `
 {
-	"caller_name": {
-		"error_code": null,
-		"caller_name": "My Business, INC",
-		"caller_type": "CONSUMER",
-	},
-	"carrier": {
-	  "error_code": null,
-	  "mobile_country_code": "310",
-	  "mobile_network_code": "456",
-	  "name": "verizon",
-	  "type": "mobile"
-	},
-	"country_code": "US",
-	"national_format": "(510) 867-5310",
-	"phone_number": "+15108675310",
-	"fraud": null,
-	"add_ons": null,
-	"url": "https://lookups.twilio.com/v1/PhoneNumbers/phone_number"
+ "caller_name": {
+  "error_code": null,
+  "caller_name": "Twilio Inc",
+  "caller_type": "CONSUMER"
+ },
+ "carrier": {
+   "error_code": null,
+   "mobile_country_code": "310",
+   "mobile_network_code": "456",
+   "name": "verizon",
+   "type": "mobile"
+ },
+ "country_code": "US",
+ "national_format": "(510) 867-5310",
+ "phone_number": "+15108675310",
+ "fraud": null,
+ "add_ons": null,
+ "url": "https://lookups.twilio.com/v1/PhoneNumbers/phone_number"
   }
 `


### PR DESCRIPTION
Adding support for multiple `Types`, such as `caller_name`, `carrier` without breaking backwards support.

After contacting Twilio's support, the only way to get `Carrier` and `CallerName` data is to combine both requests, 
such as: `Type=carrier&Type=caller-name`.

I tried to implement it in a way that it wouldn't break backwards compatibility.

https://www.twilio.com/docs/lookup/tutorials/carrier-and-caller-name#identify-a-phone-numbers-carrier-and-type