### PR TITLE
Add `as_of` to Usage API response

### DIFF
--- a/usage.go
+++ b/usage.go
@@ -34,6 +34,7 @@ type UsageRecord struct {
 	CountUnit   string `json:"count_unit"`
 	Usage       int    `json:"usage,string"`
 	UsageUnit   string `json:"usage_unit"`
+	AsOf        string `json:"as_of"` // GMT timestamp formatted as YYYY-MM-DDTHH:MM:SS+00:00
 	// TODO: handle SubresourceUris
 }
 
@@ -59,7 +60,7 @@ func (twilio *Twilio) GetUsageWithContext(ctx context.Context, category, startDa
 	var exception *Exception
 	twilioUrl := twilio.BaseUrl + "/Accounts/" + twilio.AccountSid + "/Usage/Records.json"
 
-	res, err := twilio.get(ctx, twilioUrl + "?" + formValues.Encode())
+	res, err := twilio.get(ctx, twilioUrl+"?"+formValues.Encode())
 	if err != nil {
 		return nil, nil, err
 	}

--- a/usage_test.go
+++ b/usage_test.go
@@ -59,7 +59,8 @@ const testUsageResponse = `
          "account_sid": "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX", 
          "usage": "0", 
          "start_date": "2012-08-15", 
-         "count_unit": "lookups"
+         "count_unit": "lookups",
+         "as_of": "2012-09-30T21:59:05+00:00"
       }, 
       {
          "category": "calls", 
@@ -83,7 +84,8 @@ const testUsageResponse = `
          "account_sid": "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX", 
          "usage": "21", 
          "start_date": "2012-08-15", 
-         "count_unit": "calls"
+         "count_unit": "calls",
+         "as_of": "2012-09-30T21:59:05+00:00"
       }
    ], 
    "next_page_uri": null,


### PR DESCRIPTION
Add `as_of` date (returned in string format) in `UsageRecord` response per https://www.twilio.com/docs/usage/api/usage-record#usagerecord-properties