### PR TITLE
update usage type in `UsageRecord` to match Twilio definition

### DIFF
--- a/usage.go
+++ b/usage.go
@@ -32,7 +32,7 @@ type UsageRecord struct {
 	PriceUnit   string `json:"price_unit"`
 	Count       int    `json:"count,string"`
 	CountUnit   string `json:"count_unit"`
-	Usage       int    `json:"usage,string"`
+	Usage       string `json:"usage"`
 	UsageUnit   string `json:"usage_unit"`
 	// TODO: handle SubresourceUris
 }
@@ -59,7 +59,7 @@ func (twilio *Twilio) GetUsageWithContext(ctx context.Context, category, startDa
 	var exception *Exception
 	twilioUrl := twilio.BaseUrl + "/Accounts/" + twilio.AccountSid + "/Usage/Records.json"
 
-	res, err := twilio.get(ctx, twilioUrl + "?" + formValues.Encode())
+	res, err := twilio.get(ctx, twilioUrl+"?"+formValues.Encode())
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
Twilio returns `usage` as a string, which can be parsed to an integer or decimal type depending on the `usage_unit`. Using Twilio's Python client to fetch usage records, it was clear that the string value sometimes mapped to an `int` and a `double` in others for different corresponding `usage_unit` values. It is safer to just return the string and let the caller convert it to the expected value. 