### PR TITLE
Changed import in access_token.go

### DIFF
--- a/access_token.go
+++ b/access_token.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/golang-jwt/jwt"
+	"github.com/dgrijalva/jwt-go"
 )
 
 // AccessToken holds everything required to


### PR DESCRIPTION
I was unable to run `go get github.com/sfreiberg/gotwilio` due to this error `access_token.go:91:7: undefined: jwt.StandardClaims`. I was able to fix it on my machine by changing the import in access_token.go back to [github.com/dgrijalva/jwt-go](http://github.com/dgrijalva/jwt-go) and running `go get github.com/dgrijalva/jwt-go`. 